### PR TITLE
Features/Feature Enum

### DIFF
--- a/openc2/v10/targets.py
+++ b/openc2/v10/targets.py
@@ -89,7 +89,17 @@ class EmailAddress(_Target):
 class Features(_Target):
     _type = "features"
     _properties = OrderedDict(
-        [("features", EmptyListProperty(properties.StringProperty, default=lambda: []))]
+        [
+            (
+                "features",
+                EmptyListProperty(
+                    properties.EnumProperty(
+                        allowed=["versions", "pairs", "profiles", "rate_limit"]
+                    ),
+                    default=lambda: [],
+                ),
+            )
+        ]
     )
 
     def __init__(self, features=None, *args, **kwargs):

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -83,6 +83,7 @@ def test_args_combination():
     with pytest.raises(stix2.exceptions.InvalidValueError):
         openc2.v10.Args(start_time=1, stop_time=0)
 
+
 def test_args_allow_custom():
     a = openc2.v10.Args(duration=sys.maxsize)
     foo = openc2.v10.Args(allow_custom=True, what="who", item=a)
@@ -95,6 +96,7 @@ def test_args_allow_custom():
 
     bar = openc2.core.parse_args(json.loads(foo.serialize()), allow_custom=True)
     assert foo == bar
+
 
 def test_args_custom():
     @openc2.CustomArgs("custom-args", [("id", stix2.properties.StringProperty())])
@@ -110,7 +112,7 @@ def test_args_custom():
     args = {"custom-args": json.loads(foo.serialize())}
 
     bar = openc2.core.parse_args(args, allow_custom=True)
-    assert bar['custom-args'] == foo
+    assert bar["custom-args"] == foo
 
     args = {"bad-custom-args": json.loads(foo.serialize())}
 
@@ -123,4 +125,3 @@ def test_args_custom():
     args = {"custom-args": openc2.Args(id="value", allow_custom=True)}
     with pytest.raises(ValueError):
         openc2.core.parse_args(args)
-

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -30,7 +30,7 @@ def test_cmd_create():
 
     d = json.loads(foo.serialize())
     foo = openc2.core.dict_to_openc2(d)
-    d['invalid'] = {'bad':'value'}
+    d["invalid"] = {"bad": "value"}
     with pytest.raises(stix2.exceptions.ExtraPropertiesError):
         openc2.core.dict_to_openc2(d)
 

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -25,6 +25,7 @@ def test_ipv4_address_example():
     bar = openc2.core.parse_target(json.loads(ip4.serialize()))
     assert ip4 == bar
 
+
 def test_custom_target():
     @openc2.CustomTarget("x-thing:id", [("id", stix2.properties.StringProperty())])
     class CustomTarget(object):

--- a/tests/v10/test_features.py
+++ b/tests/v10/test_features.py
@@ -23,20 +23,12 @@ def test_features_empty():
     assert f.features[0] == "pairs"
     assert f.features[1] == "versions"
 
+    with pytest.raises(stix2.exceptions.InvalidValueError):
+        openc2.v10.Features(["invalid"])
+
 
 def test_features_unique():
     # A Producer MUST NOT send a list containing more than one instance of any Feature.
     # items must be unique
     with pytest.raises(stix2.exceptions.InvalidValueError):
         openc2.v10.Features(["versions"] * 2)
-
-
-def test_features_size():
-    for s in range(10):
-        values = list(map(lambda x: str(x), list(range(s))))
-        f = openc2.v10.Features(values)
-        assert f.features == values
-
-    # max 10 items
-    with pytest.raises(stix2.exceptions.InvalidValueError):
-        openc2.v10.Features(list(map(lambda x: str(x), list(range(11)))))


### PR DESCRIPTION
* Features/Feature is now an enum based on feedback from @davaya in #27 
* Moved a test case file to v10 sub folder

- [x] I have signed the [Contributor License Agreements (CLAs)](https://www.oasis-open.org/resources/open-repositories/cla).
- [x] I have reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file.