### PR TITLE
Fixed bug with multiple custom properties in list

### DIFF
--- a/openc2/custom.py
+++ b/openc2/custom.py
@@ -162,8 +162,7 @@ def _custom_property_builder(cls, type, properties, version):
             """
             if _value:
                 return _value
-            v = self.__init__(**kwargs)
-            return self
+            return self.__class__(**kwargs)
 
     _register_extension(_CustomProperty, object_type="properties", version=version)
     return _CustomProperty

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -57,18 +57,35 @@ def test_args_custom_embed_property():
     assert foo.value[0] != None
     assert foo.value[0].value == "my_value"
 
+    foo2 = MyCustomProp(value=[MyCustomPropInner(value="my_value2")])
+    assert foo2 != None
+    assert len(foo2.value) > 0
+    assert foo2.value[0] != None
+    assert foo2.value[0].value == "my_value2"
+
+    assert foo != foo2
+
     @openc2.CustomArgs(
         "x-custom", [("value", stix2.properties.ListProperty(MyCustomProp))]
     )
     class MyCustomArgs(object):
         pass
 
-    print("bfoo", foo.serialize())
-    foo = MyCustomArgs(value=[foo])
-    print("foo", foo.serialize())
-    assert foo != None
+    bar = MyCustomArgs(value=[foo])
+    assert bar != None
     assert len(foo.value) > 0
-    assert foo.value[0] != None
-    assert len(foo.value[0].value) > 0
-    assert foo.value[0].value[0] != None
-    assert foo.value[0].value[0].value == "my_value"
+    assert bar.value[0] != None
+    assert len(bar.value[0].value) > 0
+    assert bar.value[0].value[0] != None
+    assert bar.value[0].value[0].value == "my_value"
+
+    bar = MyCustomArgs(value=[foo, foo2])
+    print('bar', bar.serialize())
+    assert bar != None
+    assert len(foo.value) > 0
+    assert bar.value[0] != None
+    assert len(bar.value[0].value) > 0
+    assert bar.value[0].value[0] != None
+    assert bar.value[0].value[0].value == "my_value"
+    assert bar.value[1].value[0] != None
+    assert bar.value[1].value[0].value == "my_value2"


### PR DESCRIPTION
This fixes a bug with multiple custom properties in a list. A test case has been added to catch this bug next time. 

- [x] I have signed the [Contributor License Agreements (CLAs)](https://www.oasis-open.org/resources/open-repositories/cla).
- [x] I have reviewed the [CONTRIBUTING.md](https://github.com/oasis-open/openc2-lycan-python/blob/master/CONTRIBUTING.md) file.